### PR TITLE
avx2 miner fix

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,10 +249,10 @@ univalue_libbitcoin_univalue_a_SOURCES = \
   univalue/univalue_read.cpp \
   univalue/univalue_write.cpp
 
-libbitcoin_crypto_x86_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(CRYPTO_X86_CXXFLAGS)
+libbitcoin_crypto_x86_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(CRYPTO_X86_CXXFLAGS) $(CRYPTO_AES_CXXFLAGS) $(CRYPTO_AVX2_CXXFLAGS)
 libbitcoin_crypto_x86_a_SOURCES = \
   aes.cpp \
-  sha512.cpp  
+  sha512.cpp
 
 # common: shared between hodlcoind, and hodlcoin-qt and non-server tools
 libbitcoin_common_a_CPPFLAGS = $(BITCOIN_INCLUDES)

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -1,6 +1,6 @@
 #include "aes.h"
 
-#ifdef __AES__
+#ifdef __x86_64__
 
 #include <stdint.h>
 #include <x86intrin.h>

--- a/src/sha512.cpp
+++ b/src/sha512.cpp
@@ -1,6 +1,6 @@
 #include "sha512.h"
 
-#if (__AVX2__) && !(__APPLE__)
+#if (__x86_64__) && !(__APPLE__)
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Clarification of this patch
===
Code with optimization should be compiled for x86_64 version, no matter if host cpu has avx2 feature or not. Since in the patternsearch.cpp there is the code that will figure out what code to run.

Also, worth to mention that optimization flags must not be applied for all cpp files. Otherwise, wallet will be crushing on cpus without avx feature because that optimization will be applied for boost library as well. And that will cause the problem.

Anyway, I tested this patch on linux, build x86_64. On both types of cpus.

Further testing is required.
